### PR TITLE
Pin react-native at 0.4.2 due to breaking changes

### DIFF
--- a/iOS/QTTT/package.json
+++ b/iOS/QTTT/package.json
@@ -6,6 +6,6 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.4.2"
+    "react-native": "0.4.2"
   }
 }


### PR DESCRIPTION
`react-native` `0.4.4` results in a build error related to `RCTWebSocketDebugger`:

Xcode[17210]: [MT] IDEFileReferenceDebug: [Load] <Xcode3FileReference, 0x7f93328df690 (Represents: <PBXFileReference:0x7f93329209d0:00481BDB1AC0C7FA00671115:name='RCTWebSocketDebugger.xcodeproj'>)> Failed to load container at path: /Users/adam/workspace/lib/qttt/iOS/QTTT/node_modules/react-native/Libraries/RCTWebSocketDebugger/RCTWebSocketDebugger.xcodeproj, Error: Error Domain=Xcode3ProjectErrorDomain Code=2 "Project /Users/adam/workspace/lib/qttt/iOS/QTTT/node_modules/react-native/Libraries/RCTWebSocketDebugger/RCTWebSocketDebugger.xcodeproj cannot be opened because it is missing its project.pbxproj file."
